### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,12 @@ project(Autoscroll)
 
 #-----------------------------------------------------------------------------
 # Extension meta-information
-set(EXTENSION_HOMEPAGE "https://github.com/moselhy/SlicerAutoscroll")
+set(EXTENSION_HOMEPAGE "https://github.com/lassoan/SlicerAutoscroll")
 set(EXTENSION_CATEGORY "Segmentation")
-set(EXTENSION_CONTRIBUTORS "Mohamed Moselhy (Western University)")
+set(EXTENSION_CONTRIBUTORS "Mohamed Moselhy (Western University), Andras Lasso (PerkLab)")
 set(EXTENSION_DESCRIPTION "Autoscroll through slices using slice range and speed")
-set(EXTENSION_ICONURL "https://github.com/moselhy/SlicerAutoscroll/raw/master/Autoscroll.png")
-set(EXTENSION_SCREENSHOTURLS "https://github.com/moselhy/SlicerAutoscroll/raw/master/docs/screenshot.png")
+set(EXTENSION_ICONURL "https://github.com/lassoan/SlicerAutoscroll/raw/master/Autoscroll.png")
+set(EXTENSION_SCREENSHOTURLS "https://github.com/lassoan/SlicerAutoscroll/raw/master/docs/screenshot.png")
 set(EXTENSION_DEPENDS "NA") # Specified as a space separated string, a list or 'NA' if any
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.